### PR TITLE
Adjust docker mount to default home assistant directory

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -111,9 +111,9 @@ runs:
         fi
         docker run --rm \
           --entrypoint "" \
-          -v $(pwd):/github/workspace \
+          -v $(pwd):/config \
           $env_file_arg \
-          --workdir /github/workspace \
+          --workdir /config \
           "ghcr.io/home-assistant/home-assistant:${{ steps.version.outputs.version }}" \
             python -m homeassistant \
               --config "${{ steps.check.outputs.path }}" \


### PR DESCRIPTION
Adjust the docker run command to use `/config` instead of `/github/workspace` to allow for `/config` references in the configuration that will be checked.